### PR TITLE
Make sure we catch failures within FreeBSD VMs

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -107,4 +107,6 @@ jobs:
               run: |
                 cd $GITHUB_WORKSPACE
                 arturo -v
-                arturo tests/test.art
+                if ! arturo tests/test.art; then
+                    exit 1
+                fi


### PR DESCRIPTION
Apparently, we need an external test - and cannot rely on just throwing a `panic.code:1` for GitHub to realize a given task has failed.