### PR TITLE
Remove "safe" builds from test matrix

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -29,7 +29,6 @@ jobs:
                 include: 
                     - {os: linux,   arch: amd64,                        do: compile}
                     - {os: linux,   arch: amd64,    support: legacy,    do: compile}
-                    - {os: linux,   arch: amd64,    mode: safe,         do: compile}
                     - {os: linux,   arch: amd64,    mode: mini,         do: compile}
                     - {os: linux,   arch: arm64,                        do: compile}
                     - {os: linux,   arch: arm64,    support: legacy,    do: compile}


### PR DESCRIPTION
They are not in use anymore...