### PR TITLE
Change release/nightly naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ jobs:
 |--------|--------|---------|-------|
 | `token` | GitHub token | *required* | Use `${{ secrets.GITHUB_TOKEN }}` |
 | `do` | `fetch`, `compile` | `fetch` | Fetch nightly or compile from source |
-| `from` | `nightly`, `release` | `nightly` | Source repository for fetch mode |
+| `from` | `latest`, `stable` | `latest` | Source repository for fetch mode |
 | `mode` | `mini`, `full` | `full` | Build configuration |
 | `os` | `linux`, `windows`, `macos`, `freebsd`, `web` | auto-detect | Target platform |
 | `arch` | `amd64`, `arm64`, `js` | auto-detect | Target architecture |

--- a/action.yml
+++ b/action.yml
@@ -36,8 +36,8 @@ inputs:
         description: 'Action to perform (fetch, compile)'
         default: 'fetch'
     from:
-        description: 'Source repository for fetch (nightly, release)'
-        default: 'nightly'
+        description: 'Source repository for fetch (latest, stable)'
+        default: 'latest'
     artifacts_only:
         description: 'Skip environment setup, just download and upload artifacts (only works with do=fetch)'
         default: 'false'

--- a/action.yml
+++ b/action.yml
@@ -184,7 +184,7 @@ runs:
           if: inputs.do == 'fetch'
           id: nightly-info
           run: |
-            REPO="${{ inputs.from == 'release' && 'arturo-lang/arturo' || 'arturo-lang/nightly' }}"
+            REPO="${{ inputs.from == 'stable' && 'arturo-lang/arturo' || 'arturo-lang/nightly' }}"
             echo "Fetching latest release from $REPO..."
             
             LATEST_RELEASE=$(curl -s -H "Authorization: token ${{ inputs.token }}" \
@@ -317,7 +317,7 @@ runs:
                   echo "Fetching Arturo nightly on FreeBSD..."
                   echo "=========================================="
                   
-                  REPO="${{ inputs.from == 'release' && 'arturo-lang/arturo' || 'arturo-lang/nightly' }}"
+                  REPO="${{ inputs.from == 'stable' && 'arturo-lang/arturo' || 'arturo-lang/nightly' }}"
                   curl -fsSL -H "Authorization: token ${{ inputs.token }}" \
                     "https://github.com/${REPO}/releases/download/${{ steps.nightly-info.outputs.release_tag }}/${{ steps.nightly-info.outputs.artifact_name }}.zip" \
                     -o /tmp/arturo.zip


### PR DESCRIPTION
Right now, we have `release` vs `nightly` which is confusing, since we otherwise refer to these two versions as `stable` (= last release from the main repo) and `latest` (= last nightly release from arturo-lang/nightly).